### PR TITLE
docs: update `ddev get` to `ddev add-on get` in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## What is this?
 
-This repository allows you to quickly install the warp speed accessibility and vast coverage tool [A11yWatch Lite](https://github.com/a11ywatch/a11ywatch) into a [Ddev](https://ddev.readthedocs.io) project using the instnructions below.
+This repository allows you to quickly install the warp speed accessibility and vast coverage tool [A11yWatch Lite](https://github.com/a11ywatch/a11ywatch) into a [Ddev](https://ddev.readthedocs.io) project using the instructions below.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -2,12 +2,23 @@
 
 ## What is this?
 
-This repository allows you to quickly install the warp speed accessibility and vast coverage tool [A11yWatch Lite](https://github.com/a11ywatch/a11ywatch) into a [Ddev](https://ddev.readthedocs.io) project using just `ddev get a11ywatch/ddev-a11ywatch`.
+This repository allows you to quickly install the warp speed accessibility and vast coverage tool [A11yWatch Lite](https://github.com/a11ywatch/a11ywatch) into a [Ddev](https://ddev.readthedocs.io) project using the instnructions below.
 
 ## Installation
 
-1. `ddev get a11ywatch/ddev-a11ywatch`
-2. `ddev restart`
+For DDEV v1.23.5 or above run
+
+```sh
+ddev add-on get a11ywatch/ddev-a11ywatch
+```
+
+For earlier versions of DDEV run
+
+```sh
+ddev get a11ywatch/ddev-a11ywatch
+```
+
+Afterwards, run `ddev restart`
 
 ## Explanation
 


### PR DESCRIPTION
In [DDEV 1.23.5](https://github.com/ddev/ddev/releases/tag/v1.23.5) the ddev get command was deprecated in favour of ddev add-on get.

This PR updates those references in the readme file. There may be some additional markdown improvements as well.

The changes were made manually, but the PR itself was automatically created - I'm doing over 100 of these. I apologise if its not 100% to the contributor standards required by this repo. Let me know if I need to change anything.